### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/plz/compute_time.py
+++ b/src/plz/compute_time.py
@@ -40,7 +40,7 @@ def main():
     s = sec % 3600
     hour = (sec - s) / 3600
     minutes = s / 60
-    print('total %d hours and %.0f mins' % (hour, minutes))
+    print('total {0:d} hours and {1:.0f} mins'.format(hour, minutes))
     print('for my lover, 小胖儿～, 13自动化老徐')
     return result
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:the0demiurge:python-test?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:the0demiurge:python-test?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
